### PR TITLE
feat: add header validation utilities

### DIFF
--- a/src/server/validation/validateMiddleware.test.ts
+++ b/src/server/validation/validateMiddleware.test.ts
@@ -1,5 +1,8 @@
+import { jsonSchema, StringMap } from '@naturalcycles/js-lib'
 import { debugResource } from '../../test/debug.resource'
-import { expressTestService } from '../../testing'
+import { ExpressApp, expressTestService } from '../../testing'
+import { getDefaultRouter } from '../getDefaultRouter'
+import { validateHeaders } from './validateMiddleware'
 
 const app = expressTestService.createAppFromResource(debugResource)
 afterAll(async () => {
@@ -38,4 +41,103 @@ Input: { pw: 'REDACTED' }",
   "name": "AppError",
 }
 `)
+})
+
+describe('validateHeader', () => {
+  let app: ExpressApp
+  interface TestResponse {
+    ok: 1
+    headers: StringMap<any>
+  }
+
+  beforeAll(async () => {
+    const resource = getDefaultRouter()
+    const schema = jsonSchema.object({
+      shortstring: jsonSchema.string().min(8).max(16),
+      numeric: jsonSchema.string(),
+      bool: jsonSchema.string(),
+      sessionid: jsonSchema.string(),
+    })
+    resource.get('/', validateHeaders(schema, { redactPaths: ['sessionid'] }), async (req, res) => {
+      res.json({ ok: 1, headers: req.headers })
+    })
+    app = expressTestService.createAppFromResource(resource)
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  test('should pass valid headers', async () => {
+    const response = await app.get<TestResponse>('', {
+      headers: {
+        shortstring: 'shortstring',
+        numeric: '123',
+        bool: '1',
+        sessionid: 'sessionid',
+      },
+    })
+
+    expect(response).toMatchObject({ ok: 1 })
+    expect(response.headers).toEqual({
+      shortstring: 'shortstring',
+      numeric: '123',
+      bool: '1',
+      sessionid: 'sessionid',
+    })
+  })
+
+  test('should throw error on invalid headers', async () => {
+    const err = await app.expectError({
+      url: '',
+      method: 'GET',
+      headers: {
+        shortstring: 'short',
+        numeric: '123',
+        bool: '1',
+        sessionid: 'sessionid',
+      },
+    })
+
+    expect(err.data.responseStatusCode).toBe(400)
+    expect(err.cause.message).toContain(
+      'request headers/shortstring must NOT have fewer than 8 characters',
+    )
+  })
+
+  test('should list all errors (and not stop at the first error)', async () => {
+    const err = await app.expectError({
+      url: '',
+      method: 'GET',
+      headers: {
+        shortstring: 'short',
+        // numeric: '123',
+        bool: '1',
+        sessionid: 'sessionid',
+      },
+    })
+
+    expect(err.data.responseStatusCode).toBe(400)
+    expect(err.cause.message).toContain(
+      'request headers/shortstring must NOT have fewer than 8 characters',
+    )
+    expect(err.cause.message).toContain("request headers must have required property 'numeric'")
+  })
+
+  test('should redact sensitive data', async () => {
+    const err = await app.expectError({
+      url: '',
+      method: 'GET',
+      headers: {
+        shortstring: 'short',
+        numeric: '127',
+        bool: '1',
+        sessionid: 'sessionid',
+      },
+    })
+
+    expect(err.data.responseStatusCode).toBe(400)
+    expect(err.cause.message).toContain("REDACTED: 'REDACTED'")
+    expect(err.cause.message).not.toContain('sessionid')
+  })
 })

--- a/src/server/validation/validateMiddleware.ts
+++ b/src/server/validation/validateMiddleware.ts
@@ -26,6 +26,13 @@ export function validateQuery(
   return validateObject('query', schema, opt)
 }
 
+export function validateHeaders(
+  schema: JsonSchema | JsonSchemaBuilder | AjvSchema,
+  opt: ReqValidationOptions<AjvValidationError> = {},
+): BackendRequestHandler {
+  return validateObject('headers', schema, opt)
+}
+
 /**
  * Validates req property (body, params or query).
  * Supports Joi schema or AjvSchema (from nodejs-lib).
@@ -33,7 +40,7 @@ export function validateQuery(
  * Throws http 400 on error.
  */
 function validateObject(
-  prop: 'body' | 'params' | 'query',
+  prop: 'body' | 'params' | 'query' | 'headers',
   schema: JsonSchema | JsonSchemaBuilder | AjvSchema,
   opt: ReqValidationOptions<AjvValidationError> = {},
 ): BackendRequestHandler {
@@ -75,6 +82,6 @@ function redact(redactPaths: string[], obj: any, error: Error): void {
     .map(path => _get(obj, path) as string)
     .filter(Boolean)
     .forEach(secret => {
-      error.message = error.message.replace(secret, REDACTED)
+      error.message = error.message.replaceAll(secret, REDACTED)
     })
 }

--- a/src/server/validation/validateRequest.ts
+++ b/src/server/validation/validateRequest.ts
@@ -26,7 +26,7 @@ function redact(redactPaths: string[], obj: any, error: Error): void {
     .map(path => _get(obj, path) as string)
     .filter(Boolean)
     .forEach(secret => {
-      error.message = error.message.replace(secret, REDACTED)
+      error.message = error.message.replaceAll(secret, REDACTED)
     })
 }
 
@@ -55,9 +55,17 @@ class ValidateRequest {
     return this.validate(req, 'params', schema, opt)
   }
 
+  headers<T>(
+    req: BackendRequest,
+    schema: AnySchema<T>,
+    opt: ReqValidationOptions<JoiValidationError> = {},
+  ): T {
+    return this.validate(req, 'headers', schema, opt)
+  }
+
   private validate<T>(
     req: BackendRequest,
-    reqProperty: 'body' | 'params' | 'query',
+    reqProperty: 'body' | 'params' | 'query' | 'headers',
     schema: AnySchema<T>,
     opt: ReqValidationOptions<JoiValidationError> = {},
   ): T {


### PR DESCRIPTION
In this PR, I added header validation utilities in the shape of:
- `validateRequest.headers` using JOI
- `validateHeaders` using JsonSchema

One potentially unexpected effect of these functions is
that they will produce lowercase headers (as the standard dictates)
since they rely on `req.headers` which contains lowercase keys.